### PR TITLE
Update base_model.py

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -260,7 +260,7 @@ class BaseModel(object):
         preds=self.infer(dev)
         dev['predict_imp']=preds
         
-        dev['rank']=dev[['aid', 'bid']].groupby('aid')['bid'].apply(lambda row: pd.Series(dict(zip(row.index, row.rank()))))-1
+        dev['rank']=dev[['aid', 'bid']].groupby('aid')['bid'].transform(lambda row: pd.Series(dict(zip(row.index, row.rank()))))-1
         dev['predict_imp']=dev['predict_imp'].apply(lambda x:np.exp(x)-1)
         dev['predict_imp']=dev['predict_imp'].apply(round)
         dev['predict_imp']=dev['predict_imp'].apply(lambda x: 0 if x<0  else x)


### PR DESCRIPTION
在python 3.5 tf1.14环境下会遇到TypeError: incompatible index of inserted column with frame index错误，修改为transform后错误消失